### PR TITLE
updated remaining user_schema tests to use data from Docs page closes #5

### DIFF
--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -3,17 +3,6 @@ from pydantic import ValidationError
 from datetime import datetime
 from app.schemas.user_schemas import UserBase, UserCreate, UserUpdate, UserResponse, UserListResponse, LoginRequest
 
-# Fixtures for common test data
-
-@pytest.fixture
-def user_update_data():
-    return {
-        "email": "john.doe.new@example.com",
-        "full_name": "John H. Doe",
-        "bio": "I specialize in backend development with Python and Node.js.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg"
-    }
-
 @pytest.fixture
 def user_response_data():
     return {
@@ -25,10 +14,6 @@ def user_response_data():
         "updated_at": datetime.now(),
         "links": []
     }
-
-@pytest.fixture
-def login_request_data():
-    return {"username": "john_doe_123", "password": "SecurePassword123!"}
 
 # Function to extract example data from a Pydantic model
 def get_model_example_data(model):
@@ -49,8 +34,9 @@ def test_user_create_valid():
     assert user.password == example_data["password"]
 
 # Tests for UserUpdate
-def test_user_update_partial(user_update_data):
-    partial_data = {"email": user_update_data["email"]}
+def test_user_update_partial():
+    example_data = get_model_example_data(UserUpdate)
+    partial_data = {"email": example_data["email"]}
     user_update = UserUpdate(**partial_data)
     assert user_update.email == partial_data["email"]
 
@@ -62,10 +48,11 @@ def test_user_response_datetime(user_response_data):
     assert user.updated_at == user_response_data["updated_at"]
 
 # Tests for LoginRequest
-def test_login_request_valid(login_request_data):
-    login = LoginRequest(**login_request_data)
-    assert login.username == login_request_data["username"]
-    assert login.password == login_request_data["password"]
+def test_login_request_valid():
+    example_data = get_model_example_data(LoginRequest)
+    login = LoginRequest(**example_data)
+    assert login.username == example_data["username"]
+    assert login.password == example_data["password"]
 
 # Parametrized tests for username and email validation
 @pytest.mark.parametrize("username", ["test_user", "test-user", "testuser123", "123test"])


### PR DESCRIPTION
Updated remaining user_schema tests to successfully validate data from the OpenAPI Docs page instead of just fixture data.